### PR TITLE
If a validator is attached to the final card (submit card)  no validation events are triggered.

### DIFF
--- a/src/bootstrap-wizard.js
+++ b/src/bootstrap-wizard.js
@@ -961,12 +961,12 @@
 
 		_onNextClick: function() {
 			this.log("handling 'next' button click");
-
-			if (this._readyToSubmit) {
+			var currentCard = this.getActiveCard();
+			if (this._readyToSubmit && currentCard.validate()) {
 				this._submit();
 			}
 			else {
-				var currentCard = this.incrementCard();
+				currentCard = this.incrementCard();
 			}
 		},
 


### PR DESCRIPTION
Validation is never fired on the final 'submit' card. Since _abstractIncrementStep does sufficient card index bounds checks (ie we never go past our last card) -- validating on _onNextClick while 'submitable' works. 

The if/else clause should be refactored to include this new validation step and just return void instead of relying on _abstractIncrementStep's error checking.
