### PR TITLE
Remove error popovers before displaying another

### DIFF
--- a/src/bootstrap-wizard.js
+++ b/src/bootstrap-wizard.js
@@ -273,6 +273,8 @@
 				if (!ret.status) {
 					failures = true;
 					el.parent(".control-group").toggleClass("error", true);
+					// Hide any existing popovers.
+					self.wizard.hidePopovers(el);
 					self.wizard.errorPopover(el, ret.msg);
 				}
 				else {
@@ -526,7 +528,7 @@
 			}
 		},
 		
-		hidePopovers: function(el, msg) {
+		hidePopovers: function(el) {
 			this.log("hiding all popovers");
 			var self = this;
 			this.el.find(".error-popover").each(function (i, popover) {


### PR DESCRIPTION
If the `retval.msg` changes after an error popover is displayed, the new error message will not be displayed because the original popover is still displayed.

Also changed the declaration of `hidePopovers` to remove the unused parameter `msg`

This request does not contain a minified update.
