### PR TITLE
remove potential bugs in demo.html #71

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -378,7 +378,7 @@
 				});
 
 				wizard.on("reset", function() {
-					wizard.modal.find(':input').val('').removeAttr('disabled');
+					wizard.modal.find(':input').removeAttr('disabled');
 					wizard.modal.find('.form-group').removeClass('has-error').removeClass('has-succes');
 					wizard.modal.find('#fqdn').data('is-valid', 0).data('lookup', 0);
 				});


### PR DESCRIPTION
The line wizard.modal.find(':input').val('') will remove radio and
hidden, because they are attribute of input. While the value of option
of select element will survived.

Could we change the example in demo.html? I believe a lot of people like
me know little about js will use the examples in demo.html directly or
make changes on these examples while don't know what it exactly it is
dong.
