### PR TITLE
Remove inline css for CSP

### DIFF
--- a/src/bootstrap-wizard.css
+++ b/src/bootstrap-wizard.css
@@ -110,6 +110,10 @@ li.wizard-nav-item {
 	bottom: 0;
 }
 
+.wizard-progress-container .progress-bar {
+	width: 0;
+}
+
 .wizard-card-container {
 	margin-left: 28%;
 }

--- a/src/bootstrap-wizard.js
+++ b/src/bootstrap-wizard.js
@@ -390,7 +390,7 @@
                                 '</div>',
                                 '<div class="wizard-progress-container">',
                                     '<div class="progress progress-striped">',
-                                        '<div class="progress-bar" style="width: 0%;"></div>',
+                                        '<div class="progress-bar"></div>',
                                     '</div>',
                                 '</div>',
                             '</div>',


### PR DESCRIPTION
Remove inline css so that it is not necessary to set a content security policy with 'unsafe-inline'